### PR TITLE
Update _modeling3d.scss

### DIFF
--- a/src/sass/layout/_modeling3d.scss
+++ b/src/sass/layout/_modeling3d.scss
@@ -123,6 +123,9 @@
     .modeling__text{        
         max-width: 510px;
     }
+    .modeling__text:not(:last-child) {
+        margin-bottom: 0;
+    }
     .modeling__block-text{
         display: flex;
         justify-content: space-between;


### PR DESCRIPTION
убрал отступ .modeling__text:not(:last-child) {margin-bottom: 16px;}, теперь там ровно 100рх